### PR TITLE
Cap 0033 changes

### DIFF
--- a/src/invariant/LedgerEntryIsValid.cpp
+++ b/src/invariant/LedgerEntryIsValid.cpp
@@ -113,7 +113,7 @@ LedgerEntryIsValid::checkIsValid(LedgerEntry const& le, uint32_t ledgerSeq,
     case DATA:
         return checkIsValid(le.data.data(), version);
     case CLAIMABLE_BALANCE:
-        return checkIsValid(le.data.claimableBalance(), version);
+        return checkIsValid(le, version);
     default:
         return "LedgerEntry has invalid type";
     }
@@ -286,9 +286,14 @@ LedgerEntryIsValid::validatePredicate(ClaimPredicate const& pred,
 }
 
 std::string
-LedgerEntryIsValid::checkIsValid(ClaimableBalanceEntry const& cbe,
-                                 uint32 version) const
+LedgerEntryIsValid::checkIsValid(LedgerEntry const& le, uint32 version) const
 {
+    if (le.ext.v() != 1 || !le.ext.v1().sponsoringID)
+    {
+        return "ClaimableBalance is not sponsored";
+    }
+
+    auto const& cbe = le.data.claimableBalance();
     if (cbe.claimants.empty())
     {
         return "ClaimableBalance claimants is empty";

--- a/src/invariant/LedgerEntryIsValid.h
+++ b/src/invariant/LedgerEntryIsValid.h
@@ -45,8 +45,7 @@ class LedgerEntryIsValid : public Invariant
     std::string checkIsValid(TrustLineEntry const& tl, uint32 version) const;
     std::string checkIsValid(OfferEntry const& oe, uint32 version) const;
     std::string checkIsValid(DataEntry const& de, uint32 version) const;
-    std::string checkIsValid(ClaimableBalanceEntry const& cbe,
-                             uint32 version) const;
+    std::string checkIsValid(LedgerEntry const& le, uint32 version) const;
 
     bool validatePredicate(ClaimPredicate const& pred, uint32_t depth) const;
 };

--- a/src/invariant/test/InvariantTestUtils.cpp
+++ b/src/invariant/test/InvariantTestUtils.cpp
@@ -73,7 +73,7 @@ store(Application& app, UpdateList const& apply, AbstractLedgerTxn* ltxPtr,
 
         if (entry && entry.current().data.type() == ACCOUNT)
         {
-            normalizeSigners(entry);
+            normalizeSigners(entry.current().data.account());
         }
     }
 
@@ -139,6 +139,41 @@ makeUpdateList(std::nullptr_t current, std::vector<LedgerEntry> const& previous)
                        return UpdateList::value_type{nullptr, prevPtr};
                    });
     return updates;
+}
+
+void
+normalizeSigners(AccountEntry& acc)
+{
+    // Get indexes after sorting by acc.signer keys
+    std::vector<std::size_t> indices(acc.signers.size());
+    std::iota(indices.begin(), indices.end(), 0);
+    std::sort(indices.begin(), indices.end(), [&acc](size_t i, size_t j) {
+        return acc.signers[i] < acc.signers[j];
+    });
+
+    // Sort both vectors based on indices from above. If a signer in acc.signers
+    // moves, the corresponding sponsoringID needs to move to the same index as
+    // well
+    xdr::xvector<Signer, MAX_SIGNERS> sortedSigners;
+    xdr::xvector<SponsorshipDescriptor, MAX_SIGNERS> sortedSignerSponsoringIDs;
+    bool aeIsV2 = acc.ext.v() == 1 && acc.ext.v1().ext.v() == 2;
+
+    for (size_t index : indices)
+    {
+        sortedSigners.emplace_back(acc.signers[index]);
+        if (aeIsV2)
+        {
+            sortedSignerSponsoringIDs.emplace_back(
+                acc.ext.v1().ext.v2().signerSponsoringIDs[index]);
+        }
+    }
+
+    acc.signers.swap(sortedSigners);
+    if (aeIsV2)
+    {
+        acc.ext.v1().ext.v2().signerSponsoringIDs.swap(
+            sortedSignerSponsoringIDs);
+    }
 }
 }
 }

--- a/src/invariant/test/InvariantTestUtils.h
+++ b/src/invariant/test/InvariantTestUtils.h
@@ -12,6 +12,7 @@ namespace stellar
 
 class Application;
 class AbstractLedgerTxn;
+struct AccountEntry;
 struct LedgerEntry;
 struct OperationResult;
 
@@ -34,5 +35,7 @@ UpdateList makeUpdateList(std::vector<LedgerEntry> const& current,
                           std::vector<LedgerEntry> const& previous);
 UpdateList makeUpdateList(std::nullptr_t current,
                           std::vector<LedgerEntry> const& previous);
+
+void normalizeSigners(AccountEntry& acc);
 }
 }

--- a/src/transactions/ClaimClaimableBalanceOpFrame.cpp
+++ b/src/transactions/ClaimClaimableBalanceOpFrame.cpp
@@ -68,8 +68,10 @@ validatePredicate(ClaimPredicate const& pred, TimePoint closeTime)
 }
 
 bool
-ClaimClaimableBalanceOpFrame::doApply(AbstractLedgerTxn& ltx)
+ClaimClaimableBalanceOpFrame::doApply(AbstractLedgerTxn& ltxOuter)
 {
+    LedgerTxn ltx(ltxOuter);
+
     auto claimableBalanceLtxEntry =
         stellar::loadClaimableBalance(ltx, mClaimClaimableBalance.balanceID);
     if (!claimableBalanceLtxEntry)
@@ -134,6 +136,8 @@ ClaimClaimableBalanceOpFrame::doApply(AbstractLedgerTxn& ltx)
     claimableBalanceLtxEntry.erase();
 
     innerResult().code(CLAIM_CLAIMABLE_BALANCE_SUCCESS);
+
+    ltx.commit();
     return true;
 }
 

--- a/src/transactions/ClaimClaimableBalanceOpFrame.h
+++ b/src/transactions/ClaimClaimableBalanceOpFrame.h
@@ -28,7 +28,7 @@ class ClaimClaimableBalanceOpFrame : public OperationFrame
 
     bool isVersionSupported(uint32_t protocolVersion) const override;
 
-    bool doApply(AbstractLedgerTxn& ltx) override;
+    bool doApply(AbstractLedgerTxn& ltxOuter) override;
     bool doCheckValid(uint32_t ledgerVersion) override;
     void insertLedgerKeysToPrefetch(
         std::unordered_set<LedgerKey>& keys) const override;

--- a/src/transactions/ConfirmAndClearSponsorOpFrame.cpp
+++ b/src/transactions/ConfirmAndClearSponsorOpFrame.cpp
@@ -24,8 +24,10 @@ ConfirmAndClearSponsorOpFrame::isVersionSupported(
 }
 
 bool
-ConfirmAndClearSponsorOpFrame::doApply(AbstractLedgerTxn& ltx)
+ConfirmAndClearSponsorOpFrame::doApply(AbstractLedgerTxn& ltxOuter)
 {
+    LedgerTxn ltx(ltxOuter);
+
     auto sponsorship = loadSponsorship(ltx, getSourceID());
     if (!sponsorship)
     {
@@ -56,6 +58,8 @@ ConfirmAndClearSponsorOpFrame::doApply(AbstractLedgerTxn& ltx)
 
     sponsorship.erase();
     innerResult().code(CONFIRM_AND_CLEAR_SPONSOR_SUCCESS);
+
+    ltx.commit();
     return true;
 }
 

--- a/src/transactions/ConfirmAndClearSponsorOpFrame.h
+++ b/src/transactions/ConfirmAndClearSponsorOpFrame.h
@@ -23,7 +23,7 @@ class ConfirmAndClearSponsorOpFrame : public OperationFrame
     ConfirmAndClearSponsorOpFrame(Operation const& op, OperationResult& res,
                                   TransactionFrame& parentTx);
 
-    bool doApply(AbstractLedgerTxn& ltx) override;
+    bool doApply(AbstractLedgerTxn& ltxOuter) override;
     bool doCheckValid(uint32_t ledgerVersion) override;
 
     static ConfirmAndClearSponsorResultCode

--- a/src/transactions/CreateClaimableBalanceOpFrame.cpp
+++ b/src/transactions/CreateClaimableBalanceOpFrame.cpp
@@ -138,8 +138,10 @@ CreateClaimableBalanceOpFrame::isVersionSupported(
 }
 
 bool
-CreateClaimableBalanceOpFrame::doApply(AbstractLedgerTxn& ltx)
+CreateClaimableBalanceOpFrame::doApply(AbstractLedgerTxn& ltxOuter)
 {
+    LedgerTxn ltx(ltxOuter);
+
     auto header = ltx.loadHeader();
     auto sourceAccount = loadSourceAccount(ltx, header);
 
@@ -231,6 +233,8 @@ CreateClaimableBalanceOpFrame::doApply(AbstractLedgerTxn& ltx)
 
     innerResult().code(CREATE_CLAIMABLE_BALANCE_SUCCESS);
     innerResult().balanceID() = claimableBalanceEntry.balanceID;
+
+    ltx.commit();
     return true;
 }
 

--- a/src/transactions/CreateClaimableBalanceOpFrame.h
+++ b/src/transactions/CreateClaimableBalanceOpFrame.h
@@ -28,7 +28,7 @@ class CreateClaimableBalanceOpFrame : public OperationFrame
 
     bool isVersionSupported(uint32_t protocolVersion) const override;
 
-    bool doApply(AbstractLedgerTxn& ltx) override;
+    bool doApply(AbstractLedgerTxn& ltxOuter) override;
     bool doCheckValid(uint32_t ledgerVersion) override;
     void insertLedgerKeysToPrefetch(
         std::unordered_set<LedgerKey>& keys) const override;

--- a/src/transactions/OfferExchange.cpp
+++ b/src/transactions/OfferExchange.cpp
@@ -1010,9 +1010,10 @@ crossOffer(AbstractLedgerTxn& ltx, LedgerTxnEntry& sellingWheatOffer,
     // Note: No changes have been stored before this point.
     if (newAmount == 0)
     { // entire offer is taken
-        sellingWheatOffer.erase();
         auto accountB = stellar::loadAccount(ltx, accountBID);
-        addNumEntries(ltx.loadHeader(), accountB, -1);
+        removeEntryWithPossibleSponsorship(
+            ltx, ltx.loadHeader(), sellingWheatOffer.current(), accountB);
+        sellingWheatOffer.erase();
     }
     else
     {

--- a/src/transactions/SetOptionsOpFrame.cpp
+++ b/src/transactions/SetOptionsOpFrame.cpp
@@ -68,6 +68,18 @@ SetOptionsOpFrame::addOrChangeSigner(AbstractLedgerTxn& ltx)
     }
 
     auto it = signers.insert(findRes.first, *mSetOptions.signer);
+
+    if (account.ext.v() == 1 && account.ext.v1().ext.v() == 2)
+    {
+        size_t n = it - account.signers.begin();
+        auto& extV2 = account.ext.v1().ext.v2();
+        // There must always be an element in signerSponsoringIDs corresponding
+        // to each element in signers. Because the signer is not sponsored, the
+        // relevant signerSponsoringID must be null.
+        extV2.signerSponsoringIDs.insert(extV2.signerSponsoringIDs.begin() + n,
+                                         SponsorshipDescriptor{});
+    }
+
     switch (createSignerWithPossibleSponsorship(ltx, header, it, sourceAccount))
     {
     case SponsorshipResult::SUCCESS:

--- a/src/transactions/SponsorFutureReservesOpFrame.cpp
+++ b/src/transactions/SponsorFutureReservesOpFrame.cpp
@@ -55,8 +55,10 @@ SponsorFutureReservesOpFrame::createSponsorshipCounter(AbstractLedgerTxn& ltx)
 }
 
 bool
-SponsorFutureReservesOpFrame::doApply(AbstractLedgerTxn& ltx)
+SponsorFutureReservesOpFrame::doApply(AbstractLedgerTxn& ltxOuter)
 {
+    LedgerTxn ltx(ltxOuter);
+
     if (loadSponsorship(ltx, mSponsorFutureReservesOp.sponsoredID))
     {
         innerResult().code(SPONSOR_FUTURE_RESERVES_ALREADY_SPONSORED);
@@ -87,6 +89,8 @@ SponsorFutureReservesOpFrame::doApply(AbstractLedgerTxn& ltx)
     }
 
     innerResult().code(SPONSOR_FUTURE_RESERVES_SUCCESS);
+
+    ltx.commit();
     return true;
 }
 

--- a/src/transactions/SponsorFutureReservesOpFrame.h
+++ b/src/transactions/SponsorFutureReservesOpFrame.h
@@ -27,7 +27,7 @@ class SponsorFutureReservesOpFrame : public OperationFrame
     SponsorFutureReservesOpFrame(Operation const& op, OperationResult& res,
                                  TransactionFrame& parentTx);
 
-    bool doApply(AbstractLedgerTxn& ltx) override;
+    bool doApply(AbstractLedgerTxn& ltxOuter) override;
     bool doCheckValid(uint32_t ledgerVersion) override;
 
     static SponsorFutureReservesResultCode

--- a/src/transactions/SponsorshipUtils.cpp
+++ b/src/transactions/SponsorshipUtils.cpp
@@ -629,21 +629,10 @@ removeEntryWithSponsorship(LedgerEntry& le, LedgerEntry& sponsoringAcc,
 }
 
 void
-createSignerWithoutSponsorship(
-    std::vector<Signer>::const_iterator const& signerIt, LedgerEntry& acc)
+createSignerWithoutSponsorship(LedgerEntry& acc)
 {
     auto& ae = acc.data.account();
     ++ae.numSubEntries;
-    if (ae.ext.v() == 1 && ae.ext.v1().ext.v() == 2)
-    {
-        size_t n = signerIt - ae.signers.begin();
-        auto& extV2 = ae.ext.v1().ext.v2();
-        // There must always be an element in signerSponsoringIDs corresponding
-        // to each element in signers. Because the signer is not sponsored, the
-        // relevant signerSponsoringID must be null.
-        extV2.signerSponsoringIDs.insert(extV2.signerSponsoringIDs.begin() + n,
-                                         {});
-    }
 }
 
 void
@@ -651,7 +640,7 @@ createSignerWithSponsorship(std::vector<Signer>::const_iterator const& signerIt,
                             LedgerEntry& sponsoringAcc,
                             LedgerEntry& sponsoredAcc)
 {
-    createSignerWithoutSponsorship(signerIt, sponsoredAcc);
+    createSignerWithoutSponsorship(sponsoredAcc);
     establishSignerSponsorship(signerIt, sponsoringAcc, sponsoredAcc);
 }
 
@@ -812,7 +801,7 @@ createSignerWithPossibleSponsorship(
             canCreateSignerWithoutSponsorship(header.current(), acc.current());
         if (res == SponsorshipResult::SUCCESS)
         {
-            createSignerWithoutSponsorship(signerIt, acc.current());
+            createSignerWithoutSponsorship(acc.current());
         }
     }
 

--- a/src/transactions/SponsorshipUtils.cpp
+++ b/src/transactions/SponsorshipUtils.cpp
@@ -551,11 +551,9 @@ canCreateSignerWithSponsorship(
                                          sponsoredAcc);
 }
 
-// TODO(jonjove): Use signerIt or remove it
 void
-canRemoveSignerWithoutSponsorship(
-    LedgerHeader const& lh, std::vector<Signer>::const_iterator const& signerIt,
-    LedgerEntry const& acc)
+canRemoveSignerWithoutSponsorship(LedgerHeader const& lh,
+                                  LedgerEntry const& acc)
 {
     if (acc.data.account().numSubEntries < 1)
     {
@@ -563,11 +561,10 @@ canRemoveSignerWithoutSponsorship(
     }
 }
 
-// TODO(jonjove): Use signerIt or remove it
 void
-canRemoveSignerWithSponsorship(
-    LedgerHeader const& lh, std::vector<Signer>::const_iterator const& signerIt,
-    LedgerEntry const& sponsoringAcc, LedgerEntry const& sponsoredAcc)
+canRemoveSignerWithSponsorship(LedgerHeader const& lh,
+                               LedgerEntry const& sponsoringAcc,
+                               LedgerEntry const& sponsoredAcc)
 {
     if (lh.ledgerVersion < 14)
     {
@@ -840,15 +837,14 @@ removeSignerWithPossibleSponsorship(
     {
         auto sponsoringAcc = loadAccount(ltx, *sponsoringID);
 
-        canRemoveSignerWithSponsorship(header.current(), signerIt,
+        canRemoveSignerWithSponsorship(header.current(),
                                        sponsoringAcc.current(), acc.current());
         removeSignerWithSponsorship(signerIt, sponsoringAcc.current(),
                                     acc.current());
     }
     else
     {
-        canRemoveSignerWithoutSponsorship(header.current(), signerIt,
-                                          acc.current());
+        canRemoveSignerWithoutSponsorship(header.current(), acc.current());
         removeSignerWithoutSponsorship(signerIt, acc.current());
     }
 }

--- a/src/transactions/SponsorshipUtils.cpp
+++ b/src/transactions/SponsorshipUtils.cpp
@@ -8,6 +8,7 @@
 #include "ledger/LedgerTxnHeader.h"
 #include "overlay/StellarXDR.h"
 #include "transactions/TransactionUtils.h"
+#include "util/XDROperators.h"
 #include "util/types.h"
 
 using namespace stellar;
@@ -726,8 +727,7 @@ removeEntryWithPossibleSponsorship(AbstractLedgerTxn& ltx,
         LedgerEntry* sponsoredAccount =
             le.data.type() == CLAIMABLE_BALANCE ? nullptr : &acc.current();
 
-        if (acc.current().data.account().accountID.ed25519() ==
-            le.ext.v1().sponsoringID->ed25519())
+        if (acc.current().data.account().accountID == *le.ext.v1().sponsoringID)
         {
             if (le.data.type() != CLAIMABLE_BALANCE)
             {

--- a/src/transactions/SponsorshipUtils.h
+++ b/src/transactions/SponsorshipUtils.h
@@ -23,7 +23,8 @@ enum class IsSignerSponsoredResult
 
 IsSignerSponsoredResult
 isSignerSponsored(std::vector<Signer>::const_iterator const& signerIt,
-                  LedgerEntry const& le);
+                  LedgerEntry const& sponsoringAcc,
+                  LedgerEntry const& sponsoredAcc);
 
 enum class SponsorshipResult
 {

--- a/src/transactions/TransactionUtils.cpp
+++ b/src/transactions/TransactionUtils.cpp
@@ -64,6 +64,27 @@ prepareLedgerEntryExtensionV1(LedgerEntry& le)
     return le.ext.v1();
 }
 
+AccountEntryExtensionV2&
+getAccountEntryExtensionV2(AccountEntry& ae)
+{
+    if (ae.ext.v() != 1 || ae.ext.v1().ext.v() != 2)
+    {
+        throw std::runtime_error("expected AccountEntry extension V2");
+    }
+    return ae.ext.v1().ext.v2();
+}
+
+LedgerEntryExtensionV1&
+getLedgerEntryExtensionV1(LedgerEntry& le)
+{
+    if (le.ext.v() != 1)
+    {
+        throw std::runtime_error("expected LedgerEntry extension V1");
+    }
+
+    return le.ext.v1();
+}
+
 static bool
 checkAuthorization(LedgerHeader const& header, LedgerEntry const& entry)
 {

--- a/src/transactions/TransactionUtils.cpp
+++ b/src/transactions/TransactionUtils.cpp
@@ -36,7 +36,8 @@ prepareAccountEntryExtensionV2(AccountEntry& ae)
     {
         extV1.ext.v(2);
         auto& extV2 = extV1.ext.v2();
-        extV2.signerSponsoringIDs.resize(ae.signers.size());
+        extV2.signerSponsoringIDs.resize(
+            static_cast<uint32_t>(ae.signers.size()));
     }
     return extV1.ext.v2();
 }

--- a/src/transactions/TransactionUtils.cpp
+++ b/src/transactions/TransactionUtils.cpp
@@ -805,21 +805,6 @@ isImmutableAuth(LedgerTxnEntry const& entry)
 }
 
 void
-normalizeSigners(LedgerTxnEntry& entry)
-{
-    auto& acc = entry.current().data.account();
-    normalizeSigners(acc);
-}
-
-void
-normalizeSigners(AccountEntry& acc)
-{
-    std::sort(
-        acc.signers.begin(), acc.signers.end(),
-        [](Signer const& s1, Signer const& s2) { return s1.key < s2.key; });
-}
-
-void
 releaseLiabilities(AbstractLedgerTxn& ltx, LedgerTxnHeader const& header,
                    LedgerTxnEntry const& offer)
 {

--- a/src/transactions/TransactionUtils.cpp
+++ b/src/transactions/TransactionUtils.cpp
@@ -619,15 +619,6 @@ getMinBalance(LedgerHeader const& header, AccountEntry const& acc)
 }
 
 int64_t
-getMinBalance(LedgerHeader const& lh, uint32_t ownerCount)
-{
-    if (lh.ledgerVersion <= 8)
-        return (2 + ownerCount) * lh.baseReserve;
-    else
-        return (2LL + ownerCount) * int64_t(lh.baseReserve);
-}
-
-int64_t
 getMinBalance(LedgerHeader const& lh, uint32_t numSubentries,
               uint32_t numSponsoring, uint32_t numSponsored)
 {

--- a/src/transactions/TransactionUtils.cpp
+++ b/src/transactions/TransactionUtils.cpp
@@ -428,47 +428,6 @@ addBuyingLiabilities(LedgerTxnHeader const& header, LedgerTxnEntry& entry,
     }
 }
 
-AddSubentryResult
-addNumEntries(LedgerTxnHeader const& header, LedgerTxnEntry& entry, int count)
-{
-    auto& acc = entry.current().data.account();
-    int newEntriesCount = unsignedToSigned(acc.numSubEntries) + count;
-    if (newEntriesCount < 0)
-    {
-        throw std::runtime_error("invalid account state");
-    }
-    if (header.current().ledgerVersion >=
-            FIRST_PROTOCOL_SUPPORTING_OPERATION_LIMITS &&
-        count > 0 && newEntriesCount > ACCOUNT_SUBENTRY_LIMIT)
-    {
-        return AddSubentryResult::TOO_MANY_SUBENTRIES;
-    }
-
-    uint32_t numSponsoring = 0;
-    uint32_t numSponsored = 0;
-    if (header.current().ledgerVersion >= 14 && acc.ext.v() == 1 &&
-        acc.ext.v1().ext.v() == 2)
-    {
-        numSponsoring = acc.ext.v1().ext.v2().numSponsoring;
-        numSponsored = acc.ext.v1().ext.v2().numSponsored;
-    }
-    int64_t effMinBalance = getMinBalance(header.current(), newEntriesCount,
-                                          numSponsoring, numSponsored);
-    if (header.current().ledgerVersion >= 10)
-    {
-        effMinBalance += getSellingLiabilities(header, entry);
-    }
-
-    // only check minBalance when attempting to add subEntries
-    if (count > 0 && acc.balance < effMinBalance)
-    {
-        // balance too low
-        return AddSubentryResult::LOW_RESERVE;
-    }
-    acc.numSubEntries = newEntriesCount;
-    return AddSubentryResult::SUCCESS;
-}
-
 bool
 addSellingLiabilities(LedgerTxnHeader const& header, LedgerTxnEntry& entry,
                       int64_t delta)

--- a/src/transactions/TransactionUtils.h
+++ b/src/transactions/TransactionUtils.h
@@ -156,9 +156,6 @@ bool isAuthRequired(ConstLedgerTxnEntry const& entry);
 
 bool isImmutableAuth(LedgerTxnEntry const& entry);
 
-void normalizeSigners(LedgerTxnEntry& entry);
-void normalizeSigners(AccountEntry& acc);
-
 void releaseLiabilities(AbstractLedgerTxn& ltx, LedgerTxnHeader const& header,
                         LedgerTxnEntry const& offer);
 

--- a/src/transactions/TransactionUtils.h
+++ b/src/transactions/TransactionUtils.h
@@ -93,15 +93,6 @@ bool addBalance(LedgerTxnHeader const& header, LedgerTxnEntry& entry,
 bool addBuyingLiabilities(LedgerTxnHeader const& header, LedgerTxnEntry& entry,
                           int64_t delta);
 
-enum class AddSubentryResult
-{
-    SUCCESS,
-    LOW_RESERVE,
-    TOO_MANY_SUBENTRIES
-};
-AddSubentryResult addNumEntries(LedgerTxnHeader const& header,
-                                LedgerTxnEntry& entry, int count);
-
 bool addSellingLiabilities(LedgerTxnHeader const& header, LedgerTxnEntry& entry,
                            int64_t delta);
 

--- a/src/transactions/TransactionUtils.h
+++ b/src/transactions/TransactionUtils.h
@@ -38,6 +38,9 @@ TrustLineEntry::_ext_t::_v1_t&
 prepareTrustLineEntryExtensionV1(TrustLineEntry& tl);
 LedgerEntryExtensionV1& prepareLedgerEntryExtensionV1(LedgerEntry& le);
 
+AccountEntryExtensionV2& getAccountEntryExtensionV2(AccountEntry& ae);
+LedgerEntryExtensionV1& getLedgerEntryExtensionV1(LedgerEntry& le);
+
 LedgerKey accountKey(AccountID const& accountID);
 LedgerKey trustlineKey(AccountID const& accountID, Asset const& asset);
 LedgerKey offerKey(AccountID const& sellerID, uint64_t offerID);

--- a/src/transactions/TransactionUtils.h
+++ b/src/transactions/TransactionUtils.h
@@ -117,7 +117,6 @@ int64_t getMaxAmountReceive(LedgerTxnHeader const& header,
                             ConstLedgerTxnEntry const& entry);
 
 int64_t getMinBalance(LedgerHeader const& header, AccountEntry const& acc);
-int64_t getMinBalance(LedgerHeader const& header, uint32_t ownerCount);
 int64_t getMinBalance(LedgerHeader const& header, uint32_t numSubentries,
                       uint32_t numSponsoring, uint32_t numSponsored);
 

--- a/src/transactions/UpdateSponsorshipOpFrame.cpp
+++ b/src/transactions/UpdateSponsorshipOpFrame.cpp
@@ -329,17 +329,29 @@ UpdateSponsorshipOpFrame::updateSignerSponsorship(AbstractLedgerTxn& ltx)
 }
 
 bool
-UpdateSponsorshipOpFrame::doApply(AbstractLedgerTxn& ltx)
+UpdateSponsorshipOpFrame::doApply(AbstractLedgerTxn& ltxOuter)
 {
+    LedgerTxn ltx(ltxOuter);
+    bool success;
+
     switch (mUpdateSponsorshipOp.type())
     {
     case UPDATE_SPONSORSHIP_LEDGER_ENTRY:
-        return updateLedgerEntrySponsorship(ltx);
+        success = updateLedgerEntrySponsorship(ltx);
+        break;
     case UPDATE_SPONSORSHIP_SIGNER:
-        return updateSignerSponsorship(ltx);
+        success = updateSignerSponsorship(ltx);
+        break;
     default:
         abort();
     }
+
+    if (success)
+    {
+        ltx.commit();
+    }
+
+    return success;
 }
 
 bool

--- a/src/transactions/UpdateSponsorshipOpFrame.h
+++ b/src/transactions/UpdateSponsorshipOpFrame.h
@@ -30,7 +30,7 @@ class UpdateSponsorshipOpFrame : public OperationFrame
     UpdateSponsorshipOpFrame(Operation const& op, OperationResult& res,
                              TransactionFrame& parentTx);
 
-    bool doApply(AbstractLedgerTxn& ltx) override;
+    bool doApply(AbstractLedgerTxn& ltxOuter) override;
     bool doCheckValid(uint32_t ledgerVersion) override;
 
     static UpdateSponsorshipResultCode

--- a/src/transactions/simulation/TxSimUtils.cpp
+++ b/src/transactions/simulation/TxSimUtils.cpp
@@ -6,6 +6,7 @@
 #include "crypto/Hex.h"
 #include "crypto/SHA.h"
 #include "crypto/SignerKey.h"
+#include "invariant/test/InvariantTestUtils.h"
 #include "transactions/TransactionUtils.h"
 
 namespace stellar
@@ -159,7 +160,7 @@ generateScaledLiveEntries(std::vector<LedgerEntry>& entries,
                         signer.weight);
                 }
             }
-            normalizeSigners(newEntry.data.account());
+            InvariantTestUtils::normalizeSigners(newEntry.data.account());
             break;
         case TRUSTLINE:
             mutateScaledAccountID(newEntry.data.trustLine().accountID,

--- a/src/transactions/test/ClaimableBalanceTests.cpp
+++ b/src/transactions/test/ClaimableBalanceTests.cpp
@@ -332,7 +332,7 @@ validateBalancesOnCreateAndClaim(TestAccount& createAcc, TestAccount& claimAcc,
             claimAccBalanceAfterClaim);
 }
 
-TEST_CASE("claimableBalance", "[tx][managedata]")
+TEST_CASE("claimableBalance", "[tx][claimablebalance]")
 {
     Config const& cfg = getTestConfig();
 

--- a/src/transactions/test/SponsorshipTestUtils.cpp
+++ b/src/transactions/test/SponsorshipTestUtils.cpp
@@ -252,9 +252,9 @@ createModifyAndRemoveSponsoredEntry(Application& app, TestAccount& sponsoredAcc,
             // Modify sponsored entry
             {
                 LedgerTxn ltx2(ltx);
-                TransactionMeta txm(2);
+                TransactionMeta txm2(2);
                 REQUIRE(tx2->checkValid(ltx2, 0, 0));
-                REQUIRE(tx2->apply(app, ltx2, txm));
+                REQUIRE(tx2->apply(app, ltx2, txm2));
 
                 check(ltx2);
                 checkSponsorship(ltx2, sponsoredAcc, 0, nullptr, nse + 1, 2, 0,
@@ -266,9 +266,9 @@ createModifyAndRemoveSponsoredEntry(Application& app, TestAccount& sponsoredAcc,
             // Modify sponsored entry while sponsored
             {
                 LedgerTxn ltx3(ltx);
-                TransactionMeta txm(2);
+                TransactionMeta txm3(2);
                 REQUIRE(tx3->checkValid(ltx3, 0, 0));
-                REQUIRE(tx3->apply(app, ltx3, txm));
+                REQUIRE(tx3->apply(app, ltx3, txm3));
 
                 check(ltx3);
                 checkSponsorship(ltx3, sponsoredAcc, 0, nullptr, nse + 1, 2, 0,
@@ -281,9 +281,9 @@ createModifyAndRemoveSponsoredEntry(Application& app, TestAccount& sponsoredAcc,
             // Remove sponsored entry
             {
                 LedgerTxn ltx4(ltx);
-                TransactionMeta txm(2);
+                TransactionMeta txm4(2);
                 REQUIRE(tx4->checkValid(ltx4, 0, 0));
-                REQUIRE(tx4->apply(app, ltx4, txm));
+                REQUIRE(tx4->apply(app, ltx4, txm4));
 
                 if (uso.type() == UPDATE_SPONSORSHIP_LEDGER_ENTRY)
                 {

--- a/src/transactions/test/TxEnvelopeTests.cpp
+++ b/src/transactions/test/TxEnvelopeTests.cpp
@@ -26,12 +26,49 @@
 #include "transactions/SignatureUtils.h"
 #include "transactions/TransactionBridge.h"
 #include "transactions/TransactionUtils.h"
+#include "transactions/test/SponsorshipTestUtils.h"
 #include "util/Logging.h"
 #include "util/Timer.h"
 
 using namespace stellar;
 using namespace stellar::txbridge;
 using namespace stellar::txtest;
+
+static void
+sign(Hash const& networkID, SecretKey key, TransactionV1Envelope& env)
+{
+    env.signatures.emplace_back(SignatureUtils::sign(
+        key, sha256(xdr::xdr_to_opaque(networkID, ENVELOPE_TYPE_TX, env.tx))));
+}
+
+static TransactionEnvelope
+envelopeFromOps(Hash const& networkID, TestAccount& source,
+                std::vector<Operation> const& ops,
+                std::vector<SecretKey> const& opKeys)
+{
+    TransactionEnvelope tx(ENVELOPE_TYPE_TX);
+    tx.v1().tx.sourceAccount = toMuxedAccount(source);
+    tx.v1().tx.fee = 100 * ops.size();
+    tx.v1().tx.seqNum = source.nextSequenceNumber();
+    std::copy(ops.begin(), ops.end(),
+              std::back_inserter(tx.v1().tx.operations));
+
+    sign(networkID, source, tx.v1());
+    for (auto const& opKey : opKeys)
+    {
+        sign(networkID, opKey, tx.v1());
+    }
+    return tx;
+}
+
+static TransactionFrameBasePtr
+transactionFrameFromOps(Hash const& networkID, TestAccount& source,
+                        std::vector<Operation> const& ops,
+                        std::vector<SecretKey> const& opKeys)
+{
+    return TransactionFrameBase::makeTransactionFromWire(
+        networkID, envelopeFromOps(networkID, source, ops, opKeys));
+}
 
 /*
   Tests that are testing the common envelope used in transactions.
@@ -1021,6 +1058,117 @@ TEST_CASE("txenvelope", "[tx][envelope]")
                                     (alternative.autoRemove ? 1 : 2));
                             REQUIRE(getAccountSigners(root, *app).size() ==
                                     (alternative.autoRemove ? 0 : 1));
+                        });
+                    }
+
+                    SECTION("success complex sponsored signatures + " +
+                            alternative.name)
+                    {
+                        for_versions_from(14, *app, [&] {
+                            auto a2 = root.create("A2", paymentAmount);
+
+                            TransactionFramePtr tx;
+                            tx = a1.tx({payment(root, 1000)});
+                            getSignatures(tx).clear();
+                            tx->addSignature(s1);
+
+                            SignerKey sk = alternative.createSigner(*tx);
+                            Signer sk1(sk, 5); // below low rights
+
+                            // add two more signers. We want to sandwich the
+                            // signer that will be removed (sk1), so we can
+                            // verify how signerSponsoringIDs changes
+                            Signer signer1 = makeSigner(getAccount("1"), 5);
+                            Signer signer2(SignerKeyUtils::hashXKey("5"), 5);
+
+                            REQUIRE(signer1.key < sk);
+                            REQUIRE(sk < signer2.key);
+
+                            // sk1 is sponsored by a2, while signer1 and signer2
+                            // are sponsored by root
+                            auto insideSignerTx = transactionFrameFromOps(
+                                app->getNetworkID(), a2,
+                                {a2.op(sponsorFutureReserves(a1)),
+                                 a1.op(setOptions(setSigner(sk1))),
+                                 a1.op(confirmAndClearSponsor())},
+                                {a1});
+                            {
+                                LedgerTxn ltx(app->getLedgerTxnRoot());
+                                TransactionMeta txm(2);
+                                REQUIRE(insideSignerTx->checkValid(ltx, 0, 0));
+                                REQUIRE(insideSignerTx->apply(*app, ltx, txm));
+                                REQUIRE(insideSignerTx->getResultCode() ==
+                                        txSUCCESS);
+                                ltx.commit();
+                            }
+
+                            auto outsideSignerTx = transactionFrameFromOps(
+                                app->getNetworkID(), root,
+                                {root.op(sponsorFutureReserves(a1)),
+                                 a1.op(setOptions(setSigner(signer1))),
+                                 a1.op(setOptions(setSigner(signer2))),
+                                 a1.op(confirmAndClearSponsor())},
+                                {a1});
+                            {
+                                LedgerTxn ltx(app->getLedgerTxnRoot());
+                                TransactionMeta txm(2);
+                                REQUIRE(outsideSignerTx->checkValid(ltx, 0, 0));
+                                REQUIRE(outsideSignerTx->apply(*app, ltx, txm));
+                                REQUIRE(outsideSignerTx->getResultCode() ==
+                                        txSUCCESS);
+                                ltx.commit();
+                            }
+
+                            {
+                                LedgerTxn ltx(app->getLedgerTxnRoot());
+                                checkSponsorship(ltx, a1.getPublicKey(),
+                                                 signer1.key, 2,
+                                                 &root.getPublicKey());
+                                checkSponsorship(ltx, a1.getPublicKey(),
+                                                 signer2.key, 2,
+                                                 &root.getPublicKey());
+                                checkSponsorship(ltx, a1.getPublicKey(), sk, 2,
+                                                 &a2.getPublicKey());
+
+                                checkSponsorship(ltx, root.getPublicKey(), 0,
+                                                 nullptr, 0, 2, 2, 0);
+                                checkSponsorship(ltx, a2.getPublicKey(), 0,
+                                                 nullptr, 0, 2, 1, 0);
+                            }
+
+                            REQUIRE(getAccountSigners(a1, *app).size() == 4);
+                            alternative.sign(*tx);
+
+                            applyTx(tx, *app);
+                            REQUIRE(tx->getResultCode() == txSUCCESS);
+                            REQUIRE(PaymentOpFrame::getInnerCode(getFirstResult(
+                                        *tx)) == PAYMENT_SUCCESS);
+                            REQUIRE(getAccountSigners(a1, *app).size() ==
+                                    (alternative.autoRemove ? 3 : 4));
+
+                            if (alternative.autoRemove)
+                            {
+                                LedgerTxn ltx(app->getLedgerTxnRoot());
+                                checkSponsorship(ltx, root.getPublicKey(), 0,
+                                                 nullptr, 0, 2, 2, 0);
+                                checkSponsorship(ltx, a2.getPublicKey(), 0,
+                                                 nullptr, 0, 2, 0, 0);
+
+                                auto ltxe = stellar::loadAccount(ltx, a1);
+                                auto const& a1Entry =
+                                    ltxe.current().data.account();
+                                auto const& sponsoringIDs =
+                                    a1Entry.ext.v1()
+                                        .ext.v2()
+                                        .signerSponsoringIDs;
+
+                                REQUIRE(sponsoringIDs.size() == 3);
+                                REQUIRE(!sponsoringIDs[0]);
+                                REQUIRE((sponsoringIDs[1] && sponsoringIDs[2]));
+                                REQUIRE(*sponsoringIDs[1] ==
+                                        root.getPublicKey());
+                                REQUIRE(*sponsoringIDs[1] == *sponsoringIDs[2]);
+                            }
                         });
                     }
 

--- a/src/transactions/test/UpdateSponsorshipTests.cpp
+++ b/src/transactions/test/UpdateSponsorshipTests.cpp
@@ -58,7 +58,7 @@ TEST_CASE("update sponsorship", "[tx][sponsorship]")
     auto app = createTestApplication(clock, getTestConfig());
     app->start();
 
-    auto minBal = [&](size_t n) {
+    auto minBal = [&](uint32_t n) {
         return app->getLedgerManager().getLastMinBalance(n);
     };
 


### PR DESCRIPTION
# Description

Resolves -
1. Remove unneeded/unsafe functions 
2. Implement a helper function to get current sponsor and use it to simplify UpdateSponsorshipOpFrame
3. Implement remove sponsored one-time signer tests (Siddharth)
4. Wrap CAP-23 and CAP-33 operations in LedgerTxn so they never “leak” (Siddharth)
5. Resolve warnings (One still needs to be addressed. More info in the google doc)
6. Add additional safety checks to SponsorshipUtils

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format`
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval.md)
